### PR TITLE
Add input mode hint to the URL text fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       </div>
 
       <form id="file-form" onsubmit="return false;">
-        <input id="file-form-input" type="text" name="file" placeholder="Internetadresse eines Wikimedia-Commons-Bildes oder eines Wikipedia-Artikels" autofocus><button type="submit" class="green-btn">Los!</button>
+        <input id="file-form-input" type="text" inputmode="url" name="file" placeholder="Internetadresse eines Wikimedia-Commons-Bildes oder eines Wikipedia-Artikels" autofocus><button type="submit" class="green-btn">Los!</button>
         <div class="container-fluid display-none" id="file-form-alert">
           <span class="glyphicon glyphicon-warning-sign"></span><span id="file-form-alert-placeholder">Alert</span>
         </div>


### PR DESCRIPTION
As suggested in the Phabricator ticket: https://phabricator.wikimedia.org/T130201
Demo: https://tools.wmflabs.org/file-reuse-test/inputmode-url/

It does not seem to have a desired phone but maybe it is just because I am using an old Schrott.
I am looking forward to hearing from reviewers if their mobile devices benefit from this change.