### PR TITLE
Accepts mobile Commons URLs and some minor improvements regarding mobile Wikipedia URLs

### DIFF
--- a/js/app/InputHandler.js
+++ b/js/app/InputHandler.js
@@ -171,7 +171,7 @@ $.extend( InputHandler.prototype, {
 	 */
 	_splitUrl: function( url ) {
 		var regExp0 = /upload.wikimedia\.org\/wikipedia\/([-a-z]{2,})\//i,
-			regExp1 = /([-a-z]{2,}(\.m)?\.wikipedia\.org)\//i,
+			regExp1 = /([-a-z]{2,})(\.m)?\.wikipedia\.org\//i,
 			regExp2 = /\/wikipedia\/([^/]+)\//,
 			matches,
 			wikiUrl,
@@ -187,7 +187,7 @@ $.extend( InputHandler.prototype, {
 			title = this._extractPageTitle( url );
 		} else if( regExp1.test( url ) ) {
 			matches = url.match( regExp1 );
-			wikiUrl = 'https://' + matches[ 1 ] + '/';
+			wikiUrl = 'https://' + matches[ 1 ] + '.wikipedia.org/';
 
 			title = this._extractPageTitle( url, false );
 

--- a/js/app/InputHandler.js
+++ b/js/app/InputHandler.js
@@ -177,7 +177,7 @@ $.extend( InputHandler.prototype, {
 			wikiUrl,
 			title;
 
-		if( url.indexOf( 'commons.wikimedia.org/' ) !== -1 ) {
+		if( url.indexOf( 'commons.wikimedia.org/' ) !== -1 || url.indexOf( 'commons.m.wikimedia.org/' ) !== -1 ) {
 			wikiUrl = 'https://commons.wikimedia.org/';
 			title = this._extractPageTitle( url );
 		} else if( regExp0.test( url ) ) {

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -27,7 +27,13 @@ var testCases = [
 			'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg#mediaviewer/File:Helene_Fischer_2010.jpg',
 			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?uselang=de',
 			'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
-			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar'
+			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
+			'https://commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+			'commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+			'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+			'commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?uselang=de',
+			'https://commons.m.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
+			'commons.m.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar'
 		],
 		expected: {
 			file: 'File:Helene_Fischer_2010.jpg',
@@ -48,7 +54,9 @@ var testCases = [
 			'http://upload.wikimedia.org/wikipedia/commons/e/e4/JapaneseToiletControlPanel.jpg',
 			'http://upload.wikimedia.org/wikipedia/commons/thumb/e/e4/JapaneseToiletControlPanel.jpg/320px-JapaneseToiletControlPanel.jpg',
 			'http://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg#mediaviewer/File:JapaneseToiletControlPanel.jpg',
-			'http://commons.wikimedia.org/wiki/User:Chris_73/Gallery_001#mediaviewer/File:JapaneseToiletControlPanel.jpg'
+			'http://commons.wikimedia.org/wiki/User:Chris_73/Gallery_001#mediaviewer/File:JapaneseToiletControlPanel.jpg',
+			'https://commons.m.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg',
+			'https://commons.m.wikimedia.org/w/index.php?title=File:JapaneseToiletControlPanel.jpg'
 		],
 		expected: {
 			file: 'File:JapaneseToiletControlPanel.jpg',
@@ -61,7 +69,9 @@ var testCases = [
 			'http://upload.wikimedia.org/wikipedia/commons/f/f4/Gerardus_t%27_Hooft_at_Harvard.jpg',
 			'http://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/Gerardus_t%27_Hooft_at_Harvard.jpg/180px-Gerardus_t%27_Hooft_at_Harvard.jpg',
 			'http://commons.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
-			'http://commons.wikimedia.org/wiki/Gerardus_%27t_Hooft#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg'
+			'http://commons.wikimedia.org/wiki/Gerardus_%27t_Hooft#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://commons.m.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://commons.m.wikimedia.org/w/index.php?title=File:Gerardus_t%27_Hooft_at_Harvard.jpg'
 		],
 		expected: {
 			file: 'File:Gerardus_t\'_Hooft_at_Harvard.jpg',
@@ -104,7 +114,8 @@ var testCases = [
 		}
 	}, {
 		input: [
-			'https://commons.wikimedia.org/wiki/File:A_Punjab_Village,_1925.webm'
+			'https://commons.wikimedia.org/wiki/File:A_Punjab_Village,_1925.webm',
+			'https://commons.m.wikimedia.org/wiki/File:A_Punjab_Village,_1925.webm'
 		],
 		expected: {
 			file: 'File:A_Punjab_Village,_1925.webm',

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -18,13 +18,13 @@ var api = new LocalApi( 'fixtures' );
 var testCases = [
 	{
 		input: [
-			'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
+			'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
 			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg',
-			'http://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
-			'http://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
-			'http://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
+			'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg',
+			'https://upload.wikimedia.org/wikipedia/commons/8/84/Helene_Fischer_2010.jpg',
+			'https://upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
 			'upload.wikimedia.org/wikipedia/commons/thumb/8/84/Helene_Fischer_2010.jpg/171px-Helene_Fischer_2010.jpg',
-			'http://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg#mediaviewer/File:Helene_Fischer_2010.jpg',
+			'https://commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg#mediaviewer/File:Helene_Fischer_2010.jpg',
 			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?uselang=de',
 			'https://commons.wikimedia.org/w/index.php?title=File:Helene_Fischer_2010.jpg&uselang=de',
 			'commons.wikimedia.org/wiki/File:Helene_Fischer_2010.jpg?foo=bar',
@@ -41,7 +41,7 @@ var testCases = [
 		}
 	}, {
 		input: [
-			'http://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Le_Bistro/24_f%C3%A9vrier_2012#mediaviewer/Fichier:Helene_Fischer_2010.jpg'
+			'https://fr.wikipedia.org/wiki/Wikip%C3%A9dia:Le_Bistro/24_f%C3%A9vrier_2012#mediaviewer/Fichier:Helene_Fischer_2010.jpg'
 		],
 		expected: {
 			file: 'File:Helene_Fischer_2010.jpg',
@@ -49,12 +49,12 @@ var testCases = [
 		}
 	}, {
 		input: [
-			'http://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg',
-			'http://commons.wikimedia.org/w/index.php?title=File:JapaneseToiletControlPanel.jpg',
-			'http://upload.wikimedia.org/wikipedia/commons/e/e4/JapaneseToiletControlPanel.jpg',
-			'http://upload.wikimedia.org/wikipedia/commons/thumb/e/e4/JapaneseToiletControlPanel.jpg/320px-JapaneseToiletControlPanel.jpg',
-			'http://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg#mediaviewer/File:JapaneseToiletControlPanel.jpg',
-			'http://commons.wikimedia.org/wiki/User:Chris_73/Gallery_001#mediaviewer/File:JapaneseToiletControlPanel.jpg',
+			'https://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg',
+			'https://commons.wikimedia.org/w/index.php?title=File:JapaneseToiletControlPanel.jpg',
+			'https://upload.wikimedia.org/wikipedia/commons/e/e4/JapaneseToiletControlPanel.jpg',
+			'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e4/JapaneseToiletControlPanel.jpg/320px-JapaneseToiletControlPanel.jpg',
+			'https://commons.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg#mediaviewer/File:JapaneseToiletControlPanel.jpg',
+			'https://commons.wikimedia.org/wiki/User:Chris_73/Gallery_001#mediaviewer/File:JapaneseToiletControlPanel.jpg',
 			'https://commons.m.wikimedia.org/wiki/File:JapaneseToiletControlPanel.jpg',
 			'https://commons.m.wikimedia.org/w/index.php?title=File:JapaneseToiletControlPanel.jpg'
 		],
@@ -64,12 +64,12 @@ var testCases = [
 		}
 	}, {
 		input: [
-			'http://commons.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
-			'http://commons.wikimedia.org/w/index.php?title=File:Gerardus_t%27_Hooft_at_Harvard.jpg',
-			'http://upload.wikimedia.org/wikipedia/commons/f/f4/Gerardus_t%27_Hooft_at_Harvard.jpg',
-			'http://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/Gerardus_t%27_Hooft_at_Harvard.jpg/180px-Gerardus_t%27_Hooft_at_Harvard.jpg',
-			'http://commons.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
-			'http://commons.wikimedia.org/wiki/Gerardus_%27t_Hooft#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://commons.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://commons.wikimedia.org/w/index.php?title=File:Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://upload.wikimedia.org/wikipedia/commons/f/f4/Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/Gerardus_t%27_Hooft_at_Harvard.jpg/180px-Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://commons.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
+			'https://commons.wikimedia.org/wiki/Gerardus_%27t_Hooft#mediaviewer/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
 			'https://commons.m.wikimedia.org/wiki/File:Gerardus_t%27_Hooft_at_Harvard.jpg',
 			'https://commons.m.wikimedia.org/w/index.php?title=File:Gerardus_t%27_Hooft_at_Harvard.jpg'
 		],
@@ -79,13 +79,13 @@ var testCases = [
 		}
 	}, {
 		input: [
-			'http://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'https://de.m.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg'
@@ -96,12 +96,12 @@ var testCases = [
 		}
 	}, {
 		input: [
-			'http://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://de.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'de.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://de.wikipedia.org/wiki/1._FC_Bamberg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.wikipedia.org/wiki/1._FC_Bamberg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'https://de.m.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'de.m.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'https://de.m.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
@@ -184,8 +184,8 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 	var testCases = [
 		{
 			input: [
-				'http://en.wikipedia.org/wiki/K%C3%B6nigsberg,_Bavaria',
-				'http://en.wikipedia.org/w/index.php?title=K%C3%B6nigsberg,_Bavaria',
+				'https://en.wikipedia.org/wiki/K%C3%B6nigsberg,_Bavaria',
+				'https://en.wikipedia.org/w/index.php?title=K%C3%B6nigsberg,_Bavaria',
 				'https://en.m.wikipedia.org/wiki/K%C3%B6nigsberg,_Bavaria',
 				'https://en.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg,_Bavaria'
 
@@ -195,12 +195,12 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 			}
 		}, {
 			input: [
-				'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
-				'http://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+				'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+				'https://de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
 				'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
 				'de.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=de',
-				'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-				'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+				'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+				'https://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
 				'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
 				'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
 				'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
@@ -278,7 +278,7 @@ QUnit.test( 'getFilename returns an error when given an URL that cannot be proce
 	var testCases = [
 		'https://www.wikimedia.de/w/images.homepage/d/d6/Pavel_Richter_WMDE.JPG',
 		'https://www.wikimedia.de/w/images.homepage/d/d6/',
-		'http://foo.bar',
+		'https://foo.bar',
 		'https://de.wikipedia.org/wiki/Lars_Kindgen',
 		'https://de.m.wikipedia.org/wiki/Lars_Kindgen'
 	];

--- a/tests/app/InputHandler.local.tests.js
+++ b/tests/app/InputHandler.local.tests.js
@@ -85,7 +85,10 @@ var testCases = [
 			'http://upload.wikimedia.org/wikipedia/de/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg'
+			'http://upload.wikimedia.org/wikipedia/de/thumb/f/fb/1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg/320px-1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'de.m.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.m.wikipedia.org/w/index.php?title=File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg'
 		],
 		expected: {
 			file: 'File:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
@@ -98,7 +101,11 @@ var testCases = [
 			'http://de.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'de.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
 			'http://de.wikipedia.org/wiki/1._FC_Bamberg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
-			'http://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg'
+			'http://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg#mediaviewer/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.m.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'de.m.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'https://de.m.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg',
+			'de.m.wikipedia.org/w/index.php?title=Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg'
 		],
 		expected: {
 			file: 'Datei:1_FC_Bamberg_-_1_FC_Nürnberg_1901.jpg',
@@ -178,7 +185,10 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 		{
 			input: [
 				'http://en.wikipedia.org/wiki/K%C3%B6nigsberg,_Bavaria',
-				'http://en.wikipedia.org/w/index.php?title=K%C3%B6nigsberg,_Bavaria'
+				'http://en.wikipedia.org/w/index.php?title=K%C3%B6nigsberg,_Bavaria',
+				'https://en.m.wikipedia.org/wiki/K%C3%B6nigsberg,_Bavaria',
+				'https://en.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg,_Bavaria'
+
 			],
 			expected: {
 				wikiUrl: 'https://en.wikipedia.org/'
@@ -192,7 +202,15 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 				'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
 				'http://de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
 				'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
-				'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de'
+				'de.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+				'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+				'https://de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=en',
+				'de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern',
+				'de.m.wikipedia.org/wiki/K%C3%B6nigsberg_in_Bayern?uselang=de',
+				'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+				'https://de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de',
+				'de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern',
+				'de.m.wikipedia.org/w/index.php?title=K%C3%B6nigsberg_in_Bayern&uselang=de'
 			],
 			expected: {
 				wikiUrl: 'https://de.wikipedia.org/'
@@ -200,7 +218,9 @@ QUnit.test( 'getFilename() returning ImageInfo objects', function( assert ) {
 		}, {
 			input: [
 				'https://commons.wikimedia.org/wiki/User:Seeteufel',
-				'commons.wikimedia.org/wiki/User:Seeteufel'
+				'commons.wikimedia.org/wiki/User:Seeteufel',
+				'https://commons.m.wikimedia.org/wiki/User:Seeteufel',
+				'commons.m.wikimedia.org/wiki/User:Seeteufel'
 			],
 			expected: {
 				wikiUrl: 'https://commons.wikimedia.org/'
@@ -259,7 +279,8 @@ QUnit.test( 'getFilename returns an error when given an URL that cannot be proce
 		'https://www.wikimedia.de/w/images.homepage/d/d6/Pavel_Richter_WMDE.JPG',
 		'https://www.wikimedia.de/w/images.homepage/d/d6/',
 		'http://foo.bar',
-		'https://de.wikipedia.org/wiki/Lars_Kindgen'
+		'https://de.wikipedia.org/wiki/Lars_Kindgen',
+		'https://de.m.wikipedia.org/wiki/Lars_Kindgen'
 	];
 
 	/**


### PR DESCRIPTION
This is mostly about task: https://phabricator.wikimedia.org/T134742

While looking at this bug I realized that when given mobile Wikipedia URL the tool makes its first API request to "mobile" API URL (`https://en.m.wikipedia.org/w/api.php`) and further requests to non-mobile API URL. It is not a big deal I think but why not make the tool always talk to non-mobile API? This is why I added https://github.com/wmde/Lizenzhinweisgenerator/commit/f82c48007dcca36eb9bf187bbf689d580ca0cbae here.

I also found really small but quite silly inconsistency resulting from the thing described above. When given `https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg` the link to the file on Commons (BTW: we should think about changing this text, as e.g. this file is not on Commons!) is the same as the entered URL, ie. `https://de.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg`. Nothing unexpected.
But when the mobile URL is given, ie. `https://de.m.wikipedia.org/wiki/Datei:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg` the link generated by the tool is slightly different: `https://de.wikipedia.org/wiki/File:1_FC_Bamberg_-_1_FC_N%C3%BCrnberg_1901.jpg`.
The difference is the file URL generated for non-mobile URL input keeps the `Datei` namespace while the URL generated for mobile URL input uses `File:` instead.
With https://github.com/wmde/Lizenzhinweisgenerator/commit/f82c48007dcca36eb9bf187bbf689d580ca0cbae it will always use `Datei` if the input used the localized namespace.

https://github.com/wmde/Lizenzhinweisgenerator/commit/16c82898e953b24d65fa5bfd445aa48294a3e476 doesn't really belong here. I can remove from the PR if preferred.

Demo here: https://tools.wmflabs.org/file-reuse-test/mobile-urls/