### PR TITLE
Fix typo in download the image link

### DIFF
--- a/i18n/en/i18n.json
+++ b/i18n/en/i18n.json
@@ -69,7 +69,7 @@
     "creator-question-mark": "Please state, if possible, your full name. A pseudonym, a nickname or “anonymous” is possible as well.",
     "same-licence": "Same license as the original work.",
     "licence-text": "License text",
-    "download-image-link": "Downlowad the image",
+    "download-image-link": "Download the image",
     "file-page-link": "Web address of the image on Wikimedia Commons",
     "done": "Done",
     "typeOfUse": "Type of use",


### PR DESCRIPTION
Taken out from https://github.com/wmde/Lizenzhinweisgenerator/pull/230
Thanks @Cladis and @AtaZh!