### PR TITLE
Do not generate HTML when url provided as GET param

### DIFF
--- a/index.base.html
+++ b/index.base.html
@@ -69,7 +69,7 @@
       </div>
 
       <form id="file-form" class="yes-script" onsubmit="return false;">
-        <input id="file-form-input" type="text" inputmode="url" name="file" placeholder="{{i18n.index.input-placeholder}}" {{inputattr}} autofocus><button type="submit" class="green-btn">{{i18n.index.go-button}}</button>
+        <input id="file-form-input" type="text" inputmode="url" name="file" placeholder="{{i18n.index.input-placeholder}}" value="{{url}}" autofocus><button type="submit" class="green-btn">{{i18n.index.go-button}}</button>
         <div class="container-fluid display-none" id="file-form-alert">
           <span class="glyphicon glyphicon-warning-sign"></span><span id="file-form-alert-placeholder">Alert</span>
         </div>

--- a/index.php
+++ b/index.php
@@ -10,10 +10,13 @@ if( !file_exists( __DIR__ . '/i18n/' . $lang . '/i18n.json' ) ) {
 $i18nData = file_get_contents( __DIR__ . '/i18n/' . $lang . '/i18n.json' );
 $i18nData = json_decode($i18nData, true);
 
+// Get the url if passed
+$url =  isset( $_GET['url'] ) ? $_GET['url'] : '';
+
 // Get the base html to output
 $html = file_get_contents( __DIR__ . '/index.base.html' );
 $html = str_replace( '{{i18n.lang}}', $lang, $html );
-$html = str_replace( '{{inputattr}}', isset( $_GET['url'] ) ? ' value="'.htmlspecialchars($_GET['url']).'"' : '', $html );
+$html = str_replace( '{{url}}', htmlspecialchars( $url ), $html );
 
 // If we have any i18n data replace the i18n codes with new strings
 if ( $i18nData && isset( $i18nData['index'] ) ) {


### PR DESCRIPTION
Following up https://github.com/wmde/Lizenzhinweisgenerator/pull/233, a small fix: do not generate HTML from PHP. Not a big deal in this case but I think it is good in general to avoid doing this if possible.

Pinging @martinkraft 