### PR TITLE
T182666 Fixed duplicate comma bug

### DIFF
--- a/js/app/DialogueEvaluation.js
+++ b/js/app/DialogueEvaluation.js
@@ -157,9 +157,14 @@ $.extend( DialogueEvaluation.prototype, {
 			attributionLink = ', ' + this._getHtmlLicence();
 		}
 
+		var editingAttribution = this._getEditingAttribution();
+		if (editingAttribution) {
+			editingAttribution = ', ' + editingAttribution;
+		}
+
 		return ( this._getAuthorAttribution() || this._getHtmlAuthor() ) + ', '
-			+ this._getHtmlTitle() + ', '
-			+ this._getEditingAttribution()
+			+ this._getHtmlTitle()
+			+ editingAttribution
 			+ attributionLink;
 	},
 

--- a/js/app/DialogueEvaluation.js
+++ b/js/app/DialogueEvaluation.js
@@ -158,7 +158,7 @@ $.extend( DialogueEvaluation.prototype, {
 		}
 
 		var editingAttribution = this._getEditingAttribution();
-		if (editingAttribution) {
+		if( editingAttribution ) {
 			editingAttribution = ', ' + editingAttribution;
 		}
 

--- a/tests/app/DialogueEvaluation.tests.js
+++ b/tests/app/DialogueEvaluation.tests.js
@@ -196,17 +196,17 @@ QUnit.test( 'online attribution shows the author the user entered', function( as
 	assert.ok( attributionContains( evaluation, 'Meh' ) );
 } );
 
-QUnit.test( 'online attribution has no duplicate comma', function( assert) {
+QUnit.test( 'online attribution has no duplicate comma', function( assert ) {
 	var licence = licences.getLicence( 'cc-by-sa-3.0' ),
 		evaluation = newEvaluation(
 			{},
 			{
 				'typeOfUse': { type: 'online' },
 				editing: { edited: 'false' },
-				licence: { licence: licence.getId() },
+				licence: { licence: licence.getId() }
 			}
 		);
-		assert.ok( !attributionContains( evaluation, ', ,' ) );
+	assert.ok( !attributionContains( evaluation, ', ,' ) );
 } );
 
 QUnit.test( 'plain text attribution for online usage is generated correctly', function( assert ) {

--- a/tests/app/DialogueEvaluation.tests.js
+++ b/tests/app/DialogueEvaluation.tests.js
@@ -196,6 +196,19 @@ QUnit.test( 'online attribution shows the author the user entered', function( as
 	assert.ok( attributionContains( evaluation, 'Meh' ) );
 } );
 
+QUnit.test( 'online attribution has no duplicate comma', function( assert) {
+	var licence = licences.getLicence( 'cc-by-sa-3.0' ),
+		evaluation = newEvaluation(
+			{},
+			{
+				'typeOfUse': { type: 'online' },
+				editing: { edited: 'false' },
+				licence: { licence: licence.getId() },
+			}
+		);
+		assert.ok( !attributionContains( evaluation, ', ,' ) );
+} );
+
 QUnit.test( 'plain text attribution for online usage is generated correctly', function( assert ) {
 	var evaluation = newEvaluation(
 		{


### PR DESCRIPTION
When the editing attribution is empty, no comma should be appended.